### PR TITLE
Update how time slice windows are calculated

### DIFF
--- a/orbit_prediction/README.md
+++ b/orbit_prediction/README.md
@@ -118,7 +118,7 @@ The CLI to create a training data set has the following arguments:
 -   `--input_path`: The path to the parquet file to load the orbit observations from.
 -   `--output_path`: The path to save the prediction/error training dataset to.
 -   `--last_n_days`: Only use observations from the last \`n\` days when creating the prediction windows. Defaults to 30.
--   `--n_pred_days`: The number days in the prediction window. Defaults to 7.
+-   `--n_pred_days`: The number days in the prediction window. Defaults to 3.
 
 
 ### Resulting Data
@@ -223,7 +223,7 @@ with the following arguments:
 -   `--st_password`: The password for space-track.org
 -   `--norad_id_file`: The path to a text file containing a single NORAD ID on each row to fetch orbit data for. If no file is passed then orbit data for all LEO RSOs will be fetched.
 -   `--ml_model_dir`: The path to the directory containing the error prediction models serialized as JSON.
--   `--n_days`: The number of days in the future to make orbit predictions for, defaults to 7.
+-   `--n_days`: The number of days in the future to make orbit predictions for, defaults to 3.
 -   `--timestep`: The frequency in seconds to make orbit predictions for, defaults 600
 -   `--output_path` The path to save the orbit prediction pickle file to. These results can be used directly by the [conjunction search UI](../conjunction_search/README.md) to search and visualize what the predicted space traffic will look like.
 

--- a/orbit_prediction/orbit_prediction/physics_model.py
+++ b/orbit_prediction/orbit_prediction/physics_model.py
@@ -139,17 +139,17 @@ def predict_orbit(window):
     # The rows that we will predict the orbit for are all the rows in the
     # `window` but the last row
     future_rows = window.iloc[:-1].reset_index()
+    # We add the epoch and the state vector components of the starting row
+    # to the rows we will use the physics model to make predictions for
     future_rows['start_epoch'] = start_epoch
+    state_vect_comps = ['r_x', 'r_y', 'r_z', 'v_x', 'v_y', 'v_z']
+    for svc in state_vect_comps:
+        future_rows[f'start_{svc}'] = start_row[svc]
     # Calculate the elapsed time from the starting epoch to the
     # the epoch of all the rows to make predictions for
     time_deltas = future_rows.epoch - future_rows.start_epoch
     future_rows['elapsed_seconds'] = time_deltas.dt.total_seconds()
-    physics_cols = ['physics_pred_r_x',
-                    'physics_pred_r_y',
-                    'physics_pred_r_z',
-                    'physics_pred_v_x',
-                    'physics_pred_v_y',
-                    'physics_pred_v_z']
+    physics_cols = [f'physics_pred_{svc}' for svc in state_vect_comps]
     # Predict the state vectors for each of the rows in the "future"
     future_rows[physics_cols] = future_rows.elapsed_seconds.apply(orbit_propagator)
     return future_rows

--- a/orbit_prediction/orbit_prediction/physics_model.py
+++ b/orbit_prediction/orbit_prediction/physics_model.py
@@ -156,7 +156,7 @@ def predict_orbit(window):
 
 
 DEFAULT_LAST_N_DAYS = 30
-DEFAULT_N_PRED_DAYS = 7
+DEFAULT_N_PRED_DAYS = 3
 
 
 def predict_orbits(df,

--- a/orbit_prediction/orbit_prediction/physics_model.py
+++ b/orbit_prediction/orbit_prediction/physics_model.py
@@ -184,8 +184,8 @@ def predict_orbits(df,
     pred_window_length = f'{n_pred_days}d'
     # For each row in `df` we create a window of all of the observations for
     # that RSO that are within `n_pred_days` of the given row
-    windows = [w for w in epoch_df.groupby('rso_id').rolling(pred_window_length)
-               if w.shape[0] == n_pred_days]
+    window_cols = ['rso_id', pd.Grouper(freq=pred_window_length)]
+    windows = [w[1] for w in epoch_df.groupby(window_cols)]
     # Predict the orbits in each window in parallel
     window_dfs = Parallel(n_jobs=-1)(delayed(predict_orbit)(w) for w in tqdm(windows))
     # Join all of the window prediction DataFrames into a single DataFrame

--- a/orbit_prediction/orbit_prediction/pred_orbits.py
+++ b/orbit_prediction/orbit_prediction/pred_orbits.py
@@ -102,7 +102,7 @@ def predict_orbit(row, pred_start, timesteps):
     return np.stack(ts_preds, axis=0)
 
 
-DEFAULT_N_DAYS = 7
+DEFAULT_N_DAYS = 3
 DEFAULT_TIMESTEP = 600
 
 def predict_orbits(df, ml_models,

--- a/orbit_prediction/orbit_prediction/pred_physics_err.py
+++ b/orbit_prediction/orbit_prediction/pred_physics_err.py
@@ -166,7 +166,8 @@ def build_train_test_sets(df, test_size=0.2):
     """
     # Features are the physics predicted state vectors and the amount of
     # time in seconds into the future the prediction was made
-    feature_cols = ['elapsed_seconds'] + get_state_vect_cols('physics_pred')
+    feature_cols = ['elapsed_seconds'] + get_state_vect_cols('physics_pred') \
+        + get_state_vect_cols('start')
     # The target values are the errors between the physical model predictions
     # and the ground truth observations
     target_cols = get_state_vect_cols('physics_err')


### PR DESCRIPTION
In this PR we update how we are calculating the prediction windows when creating the ML training data.  The `rolling` pandas function we were using was not producing the expected results and so we now use the `pandas.Grouper` functionality to create the windows.  We have also add the beginning state vector components as features to the training data.