### PR TITLE
ssa_notebook_bugfix: Wrapping the pip command in quotes

### DIFF
--- a/orbit_prediction/code_pattern/ssa_notebook.ipynb
+++ b/orbit_prediction/code_pattern/ssa_notebook.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -e git+https://github.com/IBM/spacetech-ssa.git#egg=orbit_prediction\\&subdirectory=orbit_prediction"
+    "!pip install -e \"git+https://github.com/IBM/spacetech-ssa.git#egg=orbit_prediction\\&subdirectory=orbit_prediction\""
    ]
   },
   {


### PR DESCRIPTION
The installation was breaking in Win 10, python 3.7 on pip 21.0.1

Recommended testing:
1. Check for MacOS and Ubuntu
2. Check for pip2 and pip3